### PR TITLE
fix logic for displaying day over days

### DIFF
--- a/src/lib/components/InstagramPost.svelte
+++ b/src/lib/components/InstagramPost.svelte
@@ -13,7 +13,7 @@
 	};
 
 	let timeSincePost = dateDifferenceInDays(post.timestamp); // in days
-	let unit = timeSincePost.toFixed(0) === '1' ? 'days' : 'day';
+	let unit = timeSincePost.toFixed(0) === '1' ? 'day' : 'days';
 	if (timeSincePost >= 7) {
 		timeSincePost = timeSincePost / 7; // in weeks
 		unit = timeSincePost.toFixed(0) === '1' ? 'week' : 'weeks';


### PR DESCRIPTION
## Describe your changes

Instagram post would say '1 days ago' and '3 day ago' using the wrong form of day. Fixed so grammar makes sense.
